### PR TITLE
Removed previously used test Virtualbox tools

### DIFF
--- a/packer_builder/scripts/virtualbox.sh
+++ b/packer_builder/scripts/virtualbox.sh
@@ -7,9 +7,6 @@ os_family="$(facter osfamily)"
 os_release="$(facter operatingsystemrelease)"
 os_release_major="$(facter operatingsystemrelease | awk -F. '{ print $1 }')"
 
-# Virtualbox test guest additions for problematic default guest additions
-TEST_GUEST_ADDITIONS="VBoxGuestAdditions_6.0.7-130129.iso"
-
 if [ "$PACKER_BUILDER_TYPE" != "virtualbox-iso" ]; then
     exit 0
 fi
@@ -46,17 +43,11 @@ if [[ $os_family = "Debian" || $os = "Debian" ]]; then
         sudo dnf -y groupinstall "Development Tools"
         if [[ $os_release_major -ge 28 ]]; then
             sudo dnf -y remove virtualbox-guest-additions
-            sudo rm -rf $HOME/VBoxGuestAdditions*.iso
-            wget https://www.virtualbox.org/download/testcase/$TEST_GUEST_ADDITIONS -O $HOME/$TEST_GUEST_ADDITIONS
         fi
     else
         set -e
         sudo yum -y install gcc kernel-devel kernel-headers dkms make bzip2 perl && \
         sudo yum -y groupinstall "Development Tools"
-    fi
-    if [ -f /etc/virtualbox_desktop ] && [[ "$os" = "CentOS" ]]; then
-        sudo rm -rf $HOME/VBoxGuestAdditions*.iso
-        wget https://www.virtualbox.org/download/testcase/$TEST_GUEST_ADDITIONS -O $HOME/$TEST_GUEST_ADDITIONS
     fi
     sudo mkdir -p /mnt/virtualbox
     sudo mount -o loop $HOME/VBoxGuest*.iso /mnt/virtualbox


### PR DESCRIPTION
- We had to use test Virtualbox guest additions for building correctly
on CentOS/Fedora. This is now not required.
- Closes #43