### PR TITLE
Added CLI arg to override password in distros.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [packer-builder](#packer-builder)
   - [Usage](#usage)
     - [Help](#help)
@@ -29,7 +28,7 @@ Using Packer **SHOULD** be straight forward and in most cases, it is. Packer bui
 python -m packer_builder --help
 ...
 usage: __main__.py [-h] [-d DISTRO] [-b BUILDER] [-f FILE] [-n NUMDAYS]
-                   [-o OUTPUTDIR]
+                   [-o OUTPUTDIR] [-p PASSWORD]
                    {build,generate-templates,list-distros,update-metadata}
 
 Packer builder.
@@ -48,6 +47,8 @@ optional arguments:
                         Define number of days since last build.
   -o OUTPUTDIR, --outputdir OUTPUTDIR
                         Define path to save builds.
+  -p PASSWORD, --password PASSWORD
+                        Define default password to override distros.yml
 ```
 
 ### Examples
@@ -84,6 +85,16 @@ builder (virtualbox-iso in this example).
 
 ```bash
 python -m packer_builder build -o ~/projects/packer/builds -d CentOS -b virtualbox-iso
+```
+
+#### Define Default Password At Runtime
+
+Because there might be a scenario in which you would want to override the password
+for all distros defined in `distros.yml`. You can pass this override password as
+part of the CLI arguments.
+
+```bash
+python -m packer_builder build -o ~/projects/packer/builds -p SuperSecretPass
 ```
 
 #### Generate Templates (ONLY)

--- a/packer_builder/args.py
+++ b/packer_builder/args.py
@@ -17,6 +17,8 @@ def get_args():
                         default=30)
     parser.add_argument('-o', '--outputdir',
                         help='Define path to save builds.')
+    parser.add_argument('-p', '--password',
+                        help='Define default password to override distros.yml')
     args = parser.parse_args()
     if (args.action in ['build', 'generate-templates'] and
             args.outputdir is None):

--- a/packer_builder/build.py
+++ b/packer_builder/build.py
@@ -30,6 +30,7 @@ class Build():
             self.builder = args.builder
         else:
             self.builder = 'all'
+        self.password_override = args.password
         self.load_build_manifest()
         self.iterate()
 
@@ -84,8 +85,8 @@ class Build():
                         build_image = True
                     self.logger.debug('Build image: %s', build_image)
                     if build_image:
-                        Template(self.build_dir, distro, distro_spec,
-                                 version, version_spec)
+                        Template(self.build_dir, self.password_override,
+                                 distro, distro_spec, version, version_spec)
                         self.validate()
                         self.build()
                         self.build_manifest[distro][version][

--- a/packer_builder/generate_templates.py
+++ b/packer_builder/generate_templates.py
@@ -14,6 +14,7 @@ class GenerateTemplates():
         self.logger = get_logger(__name__)
         self.distros = distros
         self.build_dir = args.outputdir
+        self.password_override = args.password
         self.current_dir = os.getcwd()
         self.generate()
 
@@ -26,8 +27,8 @@ class GenerateTemplates():
             for version, version_spec in distro_spec['versions'].items():
                 version = str(version)
                 # Generate the template
-                Template(self.build_dir, distro, distro_spec,
-                         version, version_spec)
+                Template(self.build_dir, self.password_override,
+                         distro, distro_spec, version, version_spec)
                 # Validate the generated template
                 Build.validate(self)
                 generated_template = os.path.join(

--- a/packer_builder/template.py
+++ b/packer_builder/template.py
@@ -12,13 +12,15 @@ import jinja2
 class Template():
     """Main Packer template execution."""
 
-    def __init__(self, output_dir, distro, distro_spec, version, version_spec):
+    def __init__(self, output_dir, password_override,
+                 distro, distro_spec, version, version_spec):
         self.script_dir = os.path.dirname(os.path.abspath(__file__))
         self.build_dir = output_dir
         self.build_scripts_dir = os.path.join(self.script_dir, 'scripts')
         self.distro = distro.lower()
         self.distro_spec = distro_spec
         self.http_dir = os.path.join(self.build_dir, 'http')
+        self.password_override = password_override
         self.template = dict()
         self.vagrant_box = distro_spec.get('vagrant_box')
         if self.vagrant_box is None:
@@ -46,6 +48,8 @@ class Template():
             'password': self.distro_spec['password'],
             'vm_name': f'{self.distro}-{self.version}',
         }
+        if self.password_override is not None:
+            self.template['variables']['password'] = self.password_override
 
     def get_builders(self):
         """Direct builder configurations based on builder type."""


### PR DESCRIPTION
- Based on the fact that you might want to override the default password
defined in distros.yml. You can now use the -p/--password flag to
override the default password.
- closes #49